### PR TITLE
Add cli argument to limit run time

### DIFF
--- a/tools/btrfsslower.py
+++ b/tools/btrfsslower.py
@@ -4,7 +4,7 @@
 # btrfsslower  Trace slow btrfs operations.
 #              For Linux, uses BCC, eBPF.
 #
-# USAGE: btrfsslower [-h] [-j] [-p PID] [min_ms]
+# USAGE: btrfsslower [-h] [-j] [-p PID] [min_ms] [-s]
 #
 # This script traces common btrfs file operations: reads, writes, opens, and
 # syncs. It measures the time spent in these operations, and prints details
@@ -27,6 +27,7 @@
 from __future__ import print_function
 from bcc import BPF
 import argparse
+import signal
 from time import strftime
 
 # symbols
@@ -52,6 +53,8 @@ parser.add_argument("min_ms", nargs="?", default='10',
     help="minimum I/O duration to trace, in ms (default 10)")
 parser.add_argument("--ebpf", action="store_true",
     help=argparse.SUPPRESS)
+parser.add_argument("-s", "--sec", type=int, default=None,
+    help="total time the trace should run")
 args = parser.parse_args()
 min_ms = int(args.min_ms)
 pid = args.pid
@@ -335,8 +338,24 @@ else:
 
 # read events
 b["events"].open_perf_buffer(print_event, page_cnt=64)
-while 1:
-    try:
-        b.perf_buffer_poll()
-    except KeyboardInterrupt:
-        exit()
+sec = args.sec
+# no time duration specified, run indefinitely
+if not args.sec:
+    while 1:
+        try:
+            b.perf_buffer_poll()
+        except KeyboardInterrupt:
+            exit()
+# run until time duration expires or sigint
+else:
+    def handler(signum, frame):
+        raise Exception("end of time")
+    signal.signal(signal.SIGALRM, handler)
+    signal.alarm(sec)
+    while 1:
+        try:
+            b.perf_buffer_poll()
+        except KeyboardInterrupt:
+            exit()
+        except Exception:
+            exit()


### PR DESCRIPTION
If a user is granted sudo access only to btrfsslower.py and not kill or timeout, then user is unable to limit the runtime of btrfsslower.py. The optional cli argument stops execution of program after specified number of seconds passes.